### PR TITLE
fix: Correct use of variable for Splunkbase upload

### DIFF
--- a/enforce/.circleci/config.yml
+++ b/enforce/.circleci/config.yml
@@ -5,7 +5,7 @@
 ##
 
 version: 2.1
-orbs:
+orbs:S
   go: circleci/go@0.2.0
   splunk-app-package:
     jobs:
@@ -545,7 +545,6 @@ jobs:
             PACKAGE_ID=$(crudini --get package/default/app.conf id name)
             [[ << pipeline.git.tag >> =~ ^v[0-9]*.[0-9]*.[0-9]*$ ]] || export ISPRE=-prerelease
             [ "${ISPRE}" == "-prerelease" ] && SPLUNKBASE_VIS="false" || SPLUNKBASE_VIS="true"
-            export SPLUNKBASE_SPLUNK_VERSION=$(echo << pipeline.git.tag >> | sed 's/^v\(.*\)/\1/')            
             curl -u ${SPLUNKBASE_USERNAME}:${SPLUNKBASE_PASSWORD}  --request POST https://splunkbase.splunk.com/api/v1/app/${SPLUNKBASE_ID}/new_release/ -F "files[]=@${PACKAGE}" -F "filename=${PACKAGE_ID}.spl" -F "splunk_versions=${SPLUNKBASE_SPLUNK_VERSION}" -F "visibility=${SPLUNKBASE_VIS}"
   reuse:
     docker:


### PR DESCRIPTION
When uploading to Splunk base the versions compatible should come from .splunkbase config not the build version