### PR TITLE
Fix issue with semgrep mismatch count

### DIFF
--- a/enforce/.circleci/config.yml
+++ b/enforce/.circleci/config.yml
@@ -497,14 +497,14 @@ jobs:
         SEMGREP_REPO_URL: << pipeline.project.git_url >>
         SEMGREP_BRANCH: << pipeline.git.branch >>
     docker:
-      - image: returntocorp/semgrep-agent:v1
+      - image: returntocorp/semgrep-agent:release-0.41.1
         user: root
     steps:
       - checkout
       - run:
           name: "Install Dependencies"
           command: |
-            pip3 install --upgrade semgrep
+            pip3 install semgrep==0.41.1
       - run:
           name: "Semgrep Scan"
           no_output_timeout: 1h


### PR DESCRIPTION
**Analysis:**
Semgrep has released few versions recently in which has some issue with `junit-xml` format and leads to this issue.

**Resolution:**
Fixed the semgrep version to 0.41.1 which contains the same result as the semgrep dashboard.

**Verification:**
1. salesforce: https://app.circleci.com/pipelines/github/splunk/splunk-add-on-for-salesforce/2431/workflows/348ee42f-b4ce-4548-8714-7b55fe6da14b/jobs/19743

2. servicenow: https://app.circleci.com/pipelines/github/splunk/splunk-add-on-for-servicenow/2249/workflows/64e21c31-d033-4ed8-b9a6-e40a5f4ae1ee/jobs/20283

3. Box: https://app.circleci.com/pipelines/github/splunk/splunk-add-on-for-box/1253/workflows/43e352ae-c1ac-44fe-a199-1393650ee11d/jobs/9306

4. bmc-remedy: https://app.circleci.com/pipelines/github/splunk/splunk-add-on-for-bmc-remedy/1179/workflows/d9963493-6e18-4a21-b775-f7b6337c7eb2/jobs/9598

5. Cisco-UCS: https://app.circleci.com/pipelines/github/splunk/splunk-add-on-for-cisco-ucs/1315/workflows/72d28db7-cde6-459a-ab5d-f7a2c9ad28b2/jobs/5261


