### PR TITLE
update docker-compose.yml to support uf service

### DIFF
--- a/enforce/docker-compose.yml
+++ b/enforce/docker-compose.yml
@@ -144,6 +144,25 @@ services:
       - PROXY_PASSWORD=123456
     tty: true
 
+  uf:
+    build:
+      context: .
+      dockerfile: Dockerfile-uf
+      args:
+        SPLUNK_APP_ID: ${SPLUNK_APP_ID}
+        SPLUNK_APP_PACKAGE: ${SPLUNK_APP_PACKAGE}
+        SPLUNK_VERSION: ${SPLUNK_VERSION}
+    hostname: uf
+    ports:
+      - "8089"
+    links:
+      - splunk
+    environment:
+      - SPLUNK_PASSWORD=Chang3d!
+      - SPLUNK_START_ARGS=--accept-license
+    volumes:
+      - results:/home/circleci/work
+
 volumes:
   results:
     external: false


### PR DESCRIPTION
- Updated [enforce/docker-compose.yml](https://github.com/splunk/addonfactory-repository-template/pull/43/files#diff-0adb35d198ec46336c25f5e6860ce1184f766f75c681f43df5e1b3e4138d29b1) to support uf service in the local run with `splunk-typ=docker` param.