### PR TITLE
semgrep fix, and update splunk matrix for test

### DIFF
--- a/enforce/.circleci/config.yml
+++ b/enforce/.circleci/config.yml
@@ -554,7 +554,7 @@ workflows:
           matrix:
             alias: splunk-app-test-knowledge
             parameters:
-              splunk_version: ["7.2","8.1"]
+              splunk_version: ["8.0","8.2"]
               sc4s_version: ["1"]
               test_set: ["knowledge"]
           filters:
@@ -569,7 +569,7 @@ workflows:
           matrix:
             alias: splunk-app-test-ui
             parameters:
-              splunk_version: ["7.2","8.1"]
+              splunk_version: ["8.0","8.2"]
               sc4s_version: ["1"]
               test_set: ["ui-chrome"]
           filters:
@@ -583,7 +583,7 @@ workflows:
           matrix:
             alias: splunk-app-test-modinput
             parameters:
-              splunk_version: ["7.2","8.1"]
+              splunk_version: ["8.0","8.2"]
               sc4s_version: ["1"]
               test_set: ["modinput_functional", "modinput_others"]
           filters:
@@ -597,7 +597,7 @@ workflows:
             - package
           matrix:
             parameters:
-              test_set: ["py2-2.7.17", "py3-3.7.4", "py3-3.7.8"]
+              test_set: ["py3-3.7.4", "py3-3.7.8"]
           filters:
             branches:
               only: /.*/            

--- a/enforce/.semgrepignore
+++ b/enforce/.semgrepignore
@@ -27,3 +27,4 @@ tests/
 .github/
 .reuse/
 .vscode/
+deps/

--- a/enforce/README.md
+++ b/enforce/README.md
@@ -29,5 +29,5 @@ pytest
 Using external Splunk instance with Eventgen and app pre-installed
 
 ```bash
-pytest --splunk_type=external --splunk_host=something --splunk_user=foo --splunk_password=something
+pytest --splunk-type=external --splunk-host=something --splunk-user=foo --splunk-password=something
 ```

--- a/enforce/docker-compose-ci.yml
+++ b/enforce/docker-compose-ci.yml
@@ -74,6 +74,7 @@ services:
       - SC4S_LISTEN_PFSENSE_UDP_PORT=5006
       - SC4S_ARCHIVE_GLOBAL=no
       - SC4S_LISTEN_CHECKPOINT_SPLUNK_NOISE_CONTROL=yes
+      - TEST_SC4S_ACTIVATE_EXAMPLES=yes
 
   socks5:
     image: serjs/go-socks5-proxy:latest

--- a/enforce/docker-compose.yml
+++ b/enforce/docker-compose.yml
@@ -74,6 +74,7 @@ services:
       - SC4S_LISTEN_PFSENSE_UDP_PORT=5006
       - SC4S_ARCHIVE_GLOBAL=no
       - SC4S_LISTEN_CHECKPOINT_SPLUNK_NOISE_CONTROL=yes
+      - TEST_SC4S_ACTIVATE_EXAMPLES=yes
 
   socks5:
     image: serjs/go-socks5-proxy:latest


### PR DESCRIPTION
- Updated Splunk version matrix from ["7.2","8.1"] to ["8.0","8.2"]
- Removed python2 support from unit test
- Added `deps` directory in `.semgrepignore` to skip during semgrep scanning.
- Update docker-compose-ci.yml and docker-compose.yml files to add TEST_SC4S_ACTIVATE_EXAMPLES param
- Move README.md file to enforce from seed

**Note:** We need to merge addonfactory_test_matrix_splunk dependabot PR first in the addon repo before merging these rollout changes.